### PR TITLE
fix(issue-10): scope reflection recording attribution to candidate

### DIFF
--- a/backend/app/api/candidate.py
+++ b/backend/app/api/candidate.py
@@ -12,11 +12,13 @@ from app.services.assessment import generate_assessment_download_link
 from app.services.assessment_store import (
     ReportRecord,
     get_assessment,
+    get_candidate_recording_key,
     get_latest_candidate_by_assessment,
     get_latest_report_by_assessment,
     get_candidate_by_id,
     get_report_by_candidate,
     mark_candidate_submitted,
+    store_recording_key,
     upsert_report,
 )
 from app.services.report_engine import run_scoring_and_store_report
@@ -220,8 +222,22 @@ async def local_upload_put(key: str, request: Request, settings: Settings = Depe
 
 @router.post("/notify-recording-upload")
 def notify_recording_upload(payload: dict, settings: Settings = Depends(get_settings)):
-    # Keep endpoint for compatibility; upload is already persisted by /local-upload.
-    return {"ok": True, "s3Key": payload.get("s3Key")}
+    s3_key = payload.get("s3Key")
+    email = payload.get("email")
+    assessment_id = payload.get("assessmentId")
+    recording_type = payload.get("type")
+    if s3_key and email and assessment_id is not None and recording_type:
+        try:
+            store_recording_key(
+                settings,
+                email=str(email),
+                assessment_id=int(assessment_id),
+                s3_key=str(s3_key),
+                recording_type=str(recording_type),
+            )
+        except (ValueError, TypeError):
+            pass
+    return {"ok": True, "s3Key": s3_key}
 
 
 @router.post("/api/recording/start-multipart-upload")

--- a/backend/app/services/assessment_store.py
+++ b/backend/app/services/assessment_store.py
@@ -154,6 +154,19 @@ def init_assessment_store(settings: Settings) -> None:
             """
         )
 
+        connection.execute(
+            """
+            CREATE TABLE IF NOT EXISTS recording_keys (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                email TEXT NOT NULL,
+                assessment_id INTEGER NOT NULL,
+                s3_key TEXT NOT NULL,
+                recording_type TEXT NOT NULL,
+                created_at TEXT NOT NULL
+            )
+            """
+        )
+
         _ensure_column(connection, "assessments", "question_id", "INTEGER")
         _ensure_column(connection, "assessments", "job_link", "TEXT")
         _ensure_column(connection, "assessments", "job_desc", "TEXT")
@@ -718,3 +731,43 @@ def get_latest_report_by_assessment(settings: Settings, assessment_id: int) -> R
         if row is None:
             return None
         return _row_to_report_record(row)
+
+
+def store_recording_key(
+    settings: Settings,
+    *,
+    email: str,
+    assessment_id: int,
+    s3_key: str,
+    recording_type: str,
+) -> None:
+    with _connect(settings) as connection:
+        connection.execute(
+            """
+            INSERT INTO recording_keys (email, assessment_id, s3_key, recording_type, created_at)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            (email.strip().lower(), assessment_id, s3_key, recording_type, _iso_now()),
+        )
+
+
+def get_candidate_recording_key(
+    settings: Settings,
+    *,
+    assessment_id: int,
+    email: str,
+    recording_type: str,
+) -> str | None:
+    with _connect(settings) as connection:
+        row = connection.execute(
+            """
+            SELECT s3_key FROM recording_keys
+            WHERE assessment_id = ? AND lower(email) = lower(?) AND recording_type = ?
+            ORDER BY created_at DESC
+            LIMIT 1
+            """,
+            (assessment_id, email.strip().lower(), recording_type),
+        ).fetchone()
+        if row is None:
+            return None
+        return str(row["s3_key"])

--- a/backend/app/services/report_engine.py
+++ b/backend/app/services/report_engine.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import zipfile
 
 from app.core.config import Settings
-from app.services.assessment_store import CandidateRecord, get_assessment, upsert_report
+from app.services.assessment_store import CandidateRecord, get_assessment, get_candidate_recording_key, upsert_report
 from app.services.screen_time_analyzer import analyze_screen_time
 
 
@@ -45,7 +45,23 @@ def _find_latest_assessment_recording(settings: Settings, assessment_id: int) ->
     return max(matches, key=lambda p: p.stat().st_mtime)
 
 
-def _find_latest_reflection_recording(settings: Settings, assessment_id: int) -> Path | None:
+def _find_reflection_by_key(settings: Settings, s3_key: str) -> Path | None:
+    path = Path(settings.local_recordings_dir) / s3_key
+    return path if path.is_file() else None
+
+
+def _find_latest_reflection_recording(settings: Settings, assessment_id: int, *, candidate_email: str | None = None) -> Path | None:
+    if candidate_email is not None:
+        key = get_candidate_recording_key(
+            settings,
+            assessment_id=assessment_id,
+            email=candidate_email,
+            recording_type='reflection',
+        )
+        if key is not None:
+            found = _find_reflection_by_key(settings, key)
+            if found is not None:
+                return found
     root = Path(settings.local_recordings_dir) / 'reflection' / str(assessment_id)
     if not root.exists():
         return None
@@ -273,7 +289,7 @@ def run_scoring_and_store_report(settings: Settings, candidate: CandidateRecord)
     submission = _find_latest_submission(settings, candidate.assessment_id)
     notebook = _find_latest_notebook(settings, candidate.assessment_id)
     recording = _find_latest_assessment_recording(settings, candidate.assessment_id)
-    reflection = _find_latest_reflection_recording(settings, candidate.assessment_id)
+    reflection = _find_latest_reflection_recording(settings, candidate.assessment_id, candidate_email=candidate.email)
 
     try:
         base_score, code_quality, checks, summary, diffs = _evaluate_submission(


### PR DESCRIPTION
Fixes #10

## Problem

The scoring pipeline resolves reflection recordings by globbing all `.webm` files under `reflection/{assessmentId}/` and picking the most recent by `mtime`. When two candidates share the same assessment, candidate B's reflection recording can overwrite candidate A's attribution — whichever file was modified last wins.

## Solution

The frontend already sends `email`, `assessmentId`, `s3Key`, and `type` to `POST /notify-recording-upload`, but the endpoint was a no-op. This PR:

1. **Adds a `recording_keys` table** to persist the candidate → recording key mapping.
2. **Updates `notify-recording-upload`** to store the mapping when the frontend notifies after a successful upload.
3. **Updates `_find_latest_reflection_recording`** in the scoring pipeline to first try a candidate-scoped DB lookup (by email + assessment ID), falling back to the existing assessment-wide glob for backward compatibility with recordings uploaded before this change.

No frontend changes are required — the existing `notify-recording-upload` payload already includes all the necessary fields.

## Files changed

- `backend/app/services/assessment_store.py` — new `recording_keys` table + `store_recording_key` / `get_candidate_recording_key` helpers
- `backend/app/api/candidate.py` — `notify_recording_upload` now persists the mapping
- `backend/app/services/report_engine.py` — `_find_latest_reflection_recording` tries candidate-scoped lookup first

## Testing

- Verified that the new table is created on `init_assessment_store` alongside existing tables.
- Traced the full upload flow: frontend calls `notify-recording-upload` with email/s3Key → stored in `recording_keys` → scoring pipeline resolves the correct reflection per candidate.
- The glob fallback ensures backward compatibility for any recordings uploaded before the migration.
