### PR TITLE
fix(issue-9): validate assessment exists before creating candidate in upload endpoints

### DIFF
--- a/backend/app/api/candidate.py
+++ b/backend/app/api/candidate.py
@@ -360,16 +360,15 @@ async def upload_zip(
     candidate = None
     try:
         assessment_numeric = int(assessmentId)
-        if email:
+        assessment = get_assessment(settings, assessment_numeric)
+        if email and assessment is not None:
             candidate = mark_candidate_submitted(
                 settings,
                 assessment_id=assessment_numeric,
                 email=email,
                 name=name or None,
             )
-            assessment = get_assessment(settings, assessment_numeric)
-            assessment_type = assessment.assessment_type if assessment is not None else "default"
-            _init_pending_report(settings, candidate.id, assessment_numeric, assessment_type)
+            _init_pending_report(settings, candidate.id, assessment_numeric, assessment.assessment_type)
     except ValueError:
         pass
     if candidate is not None:
@@ -415,16 +414,15 @@ async def upload_assessment4(
     candidate = None
     try:
         assessment_numeric = int(assessmentId)
-        if email:
+        assessment = get_assessment(settings, assessment_numeric)
+        if email and assessment is not None:
             candidate = mark_candidate_submitted(
                 settings,
                 assessment_id=assessment_numeric,
                 email=email,
                 name=name or None,
             )
-            assessment = get_assessment(settings, assessment_numeric)
-            assessment_type = assessment.assessment_type if assessment is not None else "assessment4-ner"
-            _init_pending_report(settings, candidate.id, assessment_numeric, assessment_type)
+            _init_pending_report(settings, candidate.id, assessment_numeric, assessment.assessment_type)
     except ValueError:
         pass
 


### PR DESCRIPTION
Fixes #9

Hey — while looking at the invite flow (which already validates assessment existence after the recent fix), I noticed the two submission upload endpoints still skip the check.

## Problem

`POST /upload-zip` and `POST /upload-assessment4` both call `mark_candidate_submitted()` **before** calling `get_assessment()`. This means a candidate row gets created even when the referenced `assessment_id` doesn't correspond to any real assessment. The code then falls back to a hardcoded default type (`"default"` / `"assessment4-ner"`) and proceeds as if nothing is wrong.

The invite paths (`/api/invite/bulk`, `/api/invite/resend`) were already patched to validate first — these two upload endpoints are the remaining surface.

## Fix

Move `get_assessment()` **before** `mark_candidate_submitted()` in both endpoints. The candidate row is only created when the assessment lookup succeeds. As a side benefit, this also removes the fallback to a hardcoded `assessment_type` — since the assessment object is guaranteed non-None at that point, we use `assessment.assessment_type` directly.

## Files changed

- `backend/app/api/candidate.py` — reorder validation in `upload_zip` and `upload_assessment4`

## Testing

- Traced both code paths to confirm `mark_candidate_submitted` is now only reachable when `get_assessment` returns a valid record.
- Existing behavior for valid assessment IDs is unchanged.
- When `assessmentId` is `"default"` (non-numeric), the `ValueError` path still skips candidate creation as before.
