### PR TITLE
fix: reorder path sanitization in _safe_key to handle backslash inputs

### DIFF
--- a/backend/app/api/candidate.py
+++ b/backend/app/api/candidate.py
@@ -29,7 +29,7 @@ _UPLOAD_SESSIONS: dict[str, dict[str, object]] = {}
 
 
 def _safe_key(name: str) -> str:
-    return name.replace("..", "").lstrip("/").replace("\\", "/")
+    return name.replace("..", "").replace("\\", "/").lstrip("/")
 
 
 def _iso_utc(ts: float) -> str:


### PR DESCRIPTION
## Problem

The `_safe_key()` helper in `backend/app/api/candidate.py` (line 32) is meant to prevent directory traversal by stripping `..` sequences and leading slashes. However, the current operation order applies `lstrip("/")` *before* `replace("\\", "/")`, so a backslash-prefixed input like `\etc\passwd` survives the slash strip and then gets its backslashes converted to forward slashes — resulting in `/etc/passwd`.

When this is joined with the base directory via `pathlib.Path(base) / result`, Python treats the leading `/` as an absolute path and ignores the base entirely.

## Solution

Swap the order of `replace("\\", "/")` and `lstrip("/")` so backslashes are normalized to forward slashes first, then the leading-slash strip catches everything:

```python
# Before
name.replace("..", "").lstrip("/").replace("\\", "/")

# After
name.replace("..", "").replace("\\", "/").lstrip("/")
```

All existing normal paths produce identical results — only the backslash edge case changes.

## Testing

Verified with several inputs:
- `\\etc\\passwd` → old: `/etc/passwd` (absolute!), new: `etc/passwd` (relative, safe)
- `recordings/test.webm` → unchanged
- `../secret` → unchanged (`secret`)
- `/etc/passwd` → unchanged (`etc/passwd`)

No test suite in the repo to run, but the change is a strict reorder of existing operations with no behavioral change for well-formed paths.