### PR TITLE
fix: send SES reminder email as HTML for parity with invite email

### DIFF
--- a/backend/app/services/assessment.py
+++ b/backend/app/services/assessment.py
@@ -101,18 +101,17 @@ def send_reminder_email(to_email: str, settings: Settings) -> None:
         _send_via_smtp(to_email, content.subject, content.html_body, content.text_body, settings)
         return
 
+    msg = MIMEMultipart()
+    msg["Subject"] = content.subject
+    msg["From"] = _sender_email(settings)
+    msg["To"] = to_email
+    msg.attach(MIMEText(content.html_body, "html"))
+
     ses = ses_client(settings)
-    ses.send_email(
+    ses.send_raw_email(
         Source=_sender_email(settings),
-        Destination={"ToAddresses": [to_email]},
-        Message={
-            "Subject": {"Data": content.subject},
-            "Body": {
-                "Text": {
-                    "Data": content.text_body
-                }
-            },
-        },
+        Destinations=[to_email],
+        RawMessage={"Data": msg.as_string()},
     )
 
 


### PR DESCRIPTION
## Problem

`send_reminder_email` in `backend/app/services/assessment.py` (lines 93-116) sends the reminder via `ses.send_email` with only a plain-text body. The `console` and `smtp` branches of the same function, and `send_assessment_email`s SES branch, all deliver the HTML body produced by `email_templates.assessment_reminder_email` — so reminder emails sent via AWS SES are the only ones that drop the InterviewOS layout.

The `html_body` is already built in `email_templates.py` (lines 89-99) and is otherwise unused on the SES path.

## Fix

Switch the SES branch of `send_reminder_email` to the same `MIMEMultipart` + `ses.send_raw_email` pattern already used by `send_assessment_email`. Reminder emails now render with the same layout as invites when the SES provider is active.

## Testing

- Syntax-checked the file with `python3 -m py_compile`.
- Traced both the SMTP and console branches to confirm they are untouched and still deliver the HTML + text bodies as before.
- The SES branch now mirrors `send_assessment_email` (same imports, same MIME layout), so behavior is consistent across the two email paths.