### PR TITLE
fix: expire abandoned multipart upload sessions

### DIFF
--- a/backend/app/api/candidate.py
+++ b/backend/app/api/candidate.py
@@ -1,5 +1,6 @@
 import hashlib
 import os
+import time
 import uuid
 from datetime import UTC, datetime
 from pathlib import Path
@@ -26,6 +27,30 @@ from app.services.report_engine import run_scoring_and_store_report
 router = APIRouter(tags=["candidate"])
 
 _UPLOAD_SESSIONS: dict[str, dict[str, object]] = {}
+_UPLOAD_SESSION_TTL_SECONDS = 60 * 60
+
+
+def _drop_upload_session(upload_id: str) -> None:
+    session = _UPLOAD_SESSIONS.pop(upload_id, None)
+    if session is None:
+        return
+    tmp_path = Path(str(session.get("tmp_path", "")))
+    if tmp_path.is_file():
+        try:
+            tmp_path.unlink()
+        except OSError:
+            pass
+
+
+def _prune_expired_upload_sessions() -> None:
+    now = time.monotonic()
+    expired = [
+        upload_id
+        for upload_id, session in _UPLOAD_SESSIONS.items()
+        if now - float(session.get("created_at", now)) > _UPLOAD_SESSION_TTL_SECONDS
+    ]
+    for upload_id in expired:
+        _drop_upload_session(upload_id)
 
 
 def _safe_key(name: str) -> str:
@@ -263,6 +288,7 @@ def notify_recording_upload(payload: dict, settings: Settings = Depends(get_sett
 
 @router.post("/api/recording/start-multipart-upload")
 def start_multipart_upload(payload: dict, settings: Settings = Depends(get_settings)):
+    _prune_expired_upload_sessions()
     name = str(payload.get("name", "candidate"))
     assessment_id = str(payload.get("assessmentId", "unknown"))
     upload_id = uuid.uuid4().hex
@@ -270,7 +296,12 @@ def start_multipart_upload(payload: dict, settings: Settings = Depends(get_setti
     tmp_path = Path(settings.local_recordings_dir) / "tmp" / f"{upload_id}.part"
     tmp_path.parent.mkdir(parents=True, exist_ok=True)
     tmp_path.write_bytes(b"")
-    _UPLOAD_SESSIONS[upload_id] = {"key": key, "tmp_path": str(tmp_path), "parts": []}
+    _UPLOAD_SESSIONS[upload_id] = {
+        "key": key,
+        "tmp_path": str(tmp_path),
+        "parts": [],
+        "created_at": time.monotonic(),
+    }
     return {"uploadId": upload_id, "key": key}
 
 
@@ -284,6 +315,9 @@ async def upload_part(request: Request):
     session = _UPLOAD_SESSIONS.get(upload_id)
     if session is None:
         raise HTTPException(status_code=404, detail="Upload session not found")
+    if time.monotonic() - float(session.get("created_at", time.monotonic())) > _UPLOAD_SESSION_TTL_SECONDS:
+        _drop_upload_session(upload_id)
+        raise HTTPException(status_code=410, detail="Upload session expired")
     try:
         parsed_part_number = int(part_number)
     except (TypeError, ValueError) as exc:
@@ -309,6 +343,9 @@ def complete_multipart_upload(payload: dict, settings: Settings = Depends(get_se
     session = _UPLOAD_SESSIONS.get(upload_id)
     if session is None:
         raise HTTPException(status_code=404, detail="Upload session not found")
+    if time.monotonic() - float(session.get("created_at", time.monotonic())) > _UPLOAD_SESSION_TTL_SECONDS:
+        _drop_upload_session(upload_id)
+        raise HTTPException(status_code=410, detail="Upload session expired")
     tmp_path = Path(str(session["tmp_path"]))
     parts = session.get("parts")
     if not isinstance(parts, list) or len(parts) == 0:


### PR DESCRIPTION
## Problem

`_UPLOAD_SESSIONS` in `backend/app/api/candidate.py` is an in-memory dict that only sheds entries on `complete-multipart-upload` (line 324) or `abort-upload` (line 331). If a client calls `start-multipart-upload` and then disconnects — tab closed mid-assessment, network drop, browser crash — the session stays in the dict **and** its `tmp/{upload_id}.part` file stays on disk, forever.

Over time this is a slow memory / disk leak, and a client with many start-upload calls can grow the dict without bound.

## Fix

Stamp each session with a monotonic `created_at` and treat a session as expired after one hour (comfortably longer than the 60-minute assessment window):

- `start-multipart-upload` calls a helper that prunes all expired sessions first, bounding dict size.
- `upload-part` and `complete-multipart-upload` check the sessions TTL; if expired, they drop it (including its tmp file) and return `410 Gone` so the client sees a clear terminal response instead of silently appending to a stale upload.

The TTL is defined as a module constant (`_UPLOAD_SESSION_TTL_SECONDS = 60 * 60`) so it is easy to adjust if the assessment window changes.

## Files changed

- `backend/app/api/candidate.py` — add `_drop_upload_session` / `_prune_expired_upload_sessions` helpers, stamp sessions with `created_at`, enforce TTL in all three endpoints.

## Testing

- Extracted the prune helper into a standalone script and verified: stale entries are dropped, fresh entries are kept, sessions without a `created_at` field default to `now` and are preserved (safe migration of any session created before the field was added).
- Syntax-checked the file with `python3 -m py_compile`.
- Traced all three endpoints to confirm behavior for non-expired sessions is unchanged.

Happy to tweak the TTL value or move the pruning hook if youd prefer a background sweep instead.