### PR TITLE
fix screen time probe timeout

### DIFF
--- a/backend/app/services/screen_time_analyzer.py
+++ b/backend/app/services/screen_time_analyzer.py
@@ -17,6 +17,7 @@ def _probe_duration_seconds(video_path: Path) -> int:
             check=True,
             capture_output=True,
             text=True,
+            timeout=30,
         )
         raw = result.stdout.strip()
         return max(0, int(round(float(raw)))) if raw else 0

--- a/backend/tests/test_screen_time_analyzer.py
+++ b/backend/tests/test_screen_time_analyzer.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from app.services.screen_time_analyzer import _probe_duration_seconds, analyze_screen_time
+
+
+class ScreenTimeAnalyzerTests(unittest.TestCase):
+    def test_missing_recording_returns_empty_usage(self):
+        usage, total_duration = analyze_screen_time("missing.webm")
+
+        self.assertEqual(usage, [])
+        self.assertEqual(total_duration, 0)
+
+    def test_probe_timeout_returns_zero_duration(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            recording = Path(tmp) / "recording.webm"
+            recording.write_bytes(b"webm-data")
+
+            with patch("app.services.screen_time_analyzer.subprocess.run") as run:
+                run.side_effect = subprocess.TimeoutExpired(["ffprobe"], timeout=30)
+
+                self.assertEqual(_probe_duration_seconds(recording), 0)
+                self.assertEqual(analyze_screen_time(recording), ([], 0))
+                self.assertEqual(run.call_args.kwargs["timeout"], 30)
+
+    def test_valid_duration_returns_single_usage_bucket(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            recording = Path(tmp) / "recording.webm"
+            recording.write_bytes(b"webm-data")
+
+            with patch("app.services.screen_time_analyzer.subprocess.run") as run:
+                run.return_value.stdout = "12.4\n"
+
+                usage, total_duration = analyze_screen_time(recording)
+
+        self.assertEqual(total_duration, 12)
+        self.assertEqual(usage, [{"name": "Screen Recording", "duration": 12}])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

`backend/app/services/screen_time_analyzer.py` shells out to `ffprobe` when a report includes a screen recording. If `ffprobe` hangs on a malformed or unusual media file, the report pipeline can block indefinitely because the subprocess call had no timeout.

## Solution

This adds a 30-second timeout to the `ffprobe` call. The existing exception handling already treats probe failures as an unavailable duration, so timeout behavior now follows the same safe fallback path and returns no screen-time usage instead of blocking.

I also added focused unit coverage for:
- missing recordings returning empty usage
- `ffprobe` timeout fallback behavior
- a valid probed duration producing the expected single usage bucket

## Testing

Ran the backend test suite in a sandbox container:

```bash
python3 -m pip install -r requirements.txt
python3 -m unittest discover -s tests -v
```

Result: 11 tests passed.