### PR TITLE
fix grader archive path validation

### DIFF
--- a/grader/app/main.py
+++ b/grader/app/main.py
@@ -59,11 +59,14 @@ def run_cmd(args: list[str], *, cwd: Path | None = None, timeout: int = 120, env
 
 
 def safe_extract(zip_path: Path, dest: Path) -> Path:
+    destination = dest.resolve()
     with zipfile.ZipFile(zip_path) as archive:
         for member in archive.infolist():
             target = (dest / member.filename).resolve()
-            if not str(target).startswith(str(dest.resolve())):
-                raise ValueError(f"Unsafe archive path: {member.filename}")
+            try:
+                target.relative_to(destination)
+            except ValueError:
+                raise ValueError(f"Unsafe archive path: {member.filename}") from None
         archive.extractall(dest)
     return normalize_root(dest)
 

--- a/grader/tests/test_worker_core.py
+++ b/grader/tests/test_worker_core.py
@@ -18,6 +18,15 @@ class WorkerCoreTests(unittest.TestCase):
             with self.assertRaises(ValueError):
                 safe_extract(archive, root / "out")
 
+    def test_safe_extract_blocks_sibling_prefix_escape(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            archive = root / "bad-prefix.zip"
+            with zipfile.ZipFile(archive, "w") as zipf:
+                zipf.writestr("../out-evil/escape.txt", "bad")
+            with self.assertRaises(ValueError):
+                safe_extract(archive, root / "out")
+
     def test_structural_similarity_scores_nested_json(self):
         expected = {"name": "Alice", "items": [{"price": 10}, {"price": 20}]}
         actual = {"name": "Alice", "items": [{"price": 10}, {"price": 25}]}


### PR DESCRIPTION
Hey! I noticed a small edge case in the grader ZIP extraction guard while reading through `grader/app/main.py`.

The current check compares resolved paths with `startswith`, which correctly blocks obvious `../escape.txt` traversal but can be tripped up by sibling directories that share the destination prefix, such as `out` and `out-evil`. This PR switches the guard to `Path.relative_to()`, so extracted paths must be genuinely inside the destination directory.

I added a regression test covering the sibling-prefix escape case alongside the existing traversal test.

Testing:

```bash
python3 -m pip install -r requirements.txt
python3 -m unittest discover -s tests -v
```

Result: 3 tests passed.